### PR TITLE
Add test db check when importing data

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.init = initialData => t => new Promise((resolve, reject) => {
     let conn
     return r.connect({}).then(_ => { conn = _ })
       .then(() => Promise.all(
-        Object.keys(initialData).map(db => r.dbCreate(db).run(conn))
+        Object.keys(initialData).map(db => db !== 'test' && r.dbCreate(db).run(conn))
       ))
       .then(() => Promise.all(
         collectTables(initialData).map(([db, table]) => r.db(db).tableCreate(table).run(conn))

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -13,7 +13,12 @@ const TEST_DATA = {
     data: [
       { something: true }
     ]
-  }
+  },
+  test: {
+    data: [
+      { something: true },
+    ],
+  },
 }
 
 test.before('Initialize DB', init(TEST_DATA))
@@ -34,6 +39,7 @@ shouldDatabaseExist.title = (_, input, expected) => `Database ${input} should${e
 
 test(shouldDatabaseExist, 'fp', true)
 test(shouldDatabaseExist, 'meta', true)
+test(shouldDatabaseExist, 'test', true)
 test(shouldDatabaseExist, 'sugar', false)
 
 async function shouldUserExist (t, name, expected) {


### PR DESCRIPTION
RethinkDB comes shipped with a `test` database, and therefore my tests were hanging when I attempted to import a db with that name, i.e.:

```
const TEST_DATA = {
  test: {
    users: [{ id: '1', name: 'Bob' }],
  },
}
```

So I added a check that simply skips creating the database if the name is `test`.
