### PR TITLE
Really high PIDs exceed the maximum RethinkDB port

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,15 @@
 const { spawn } = require('child_process')
 const rimraf = require('rimraf')
 
+const getPortOffset = pid => {
+  const maxOffset = 65535 - 28015
+  return pid - (Math.floor(pid / maxOffset) * maxOffset)
+}
+
 let rethink
 
 module.exports.init = initialData => t => new Promise((resolve, reject) => {
-  const offset = process.pid % (65535 - 28015)
+  const offset = getPortOffset(process.pid)
   const port = 28015 + offset
   const r = require('rethinkdb')
 
@@ -82,3 +87,5 @@ function collectDocuments (data) {
                .reduce((a, b) => a.concat(b))
                .reduce((a, b) => a.concat(b))
 }
+
+module.exports.getPortOffset = getPortOffset

--- a/test/port-offset.js
+++ b/test/port-offset.js
@@ -1,0 +1,15 @@
+import test from 'ava'
+import { getPortOffset } from '../'
+
+test('port offsets shouldn\'t exceed the maximum offset', async t => {
+  const maxOffset = 65535 - 28015
+
+  t.true(getPortOffset(0) <= maxOffset)
+  t.true(getPortOffset(10) <= maxOffset)
+  t.true(getPortOffset(maxOffset / 2) <= maxOffset)
+  t.true(getPortOffset(maxOffset - 1) <= maxOffset)
+  t.true(getPortOffset(maxOffset + 1) <= maxOffset)
+  t.true(getPortOffset(maxOffset) <= maxOffset)
+  t.true(getPortOffset(maxOffset * 2) <= maxOffset)
+  t.true(getPortOffset(maxOffset * 2.5) <= maxOffset)
+});


### PR DESCRIPTION
Hi again 😄 

When calculating the port offset, the modulo operator breaks down when the PID exceeds `(65535 - 28015)`. Also, I'm not entirely sure how accurate this is, but I think that modulo operator will, in very rare occasions, create port collisions if a lot of RethinkDB instances are running concurrently. So, I wrote a very basic function without the modulo operator that shouldn't ever exceed the maximum port offset and will never create port collisions (unless someone is running over 35,720 concurrent instances, which is just madness).
