### PR TITLE
Updated to AVA v0.21.0, added Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - 6
+  - 8
+
+env:
+  - AVA_VERSION=0.15.2
+  - AVA_VERSION=0.21.0
+
+before_script:
+  - npm install ava@$AVA_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 
+addons:
+  apt:
+    packages:
+      - rethinkdb
+    sources:
+      - sourceline: 'deb http://download.rethinkdb.com/apt precise main'
+
 node_js:
   - 6
   - 8

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
     "url": "https://github.com/rrdelaney/ava-rethinkdb/issues"
   },
   "homepage": "https://github.com/rrdelaney/ava-rethinkdb",
+  "peerDependencies": {
+    "ava": "^0.21.0 || <= 0.21.0"
+  },
   "devDependencies": {
-    "ava": "^0.15.2",
+    "ava": "^0.21.0",
     "rethinkdb": "^2.3.2",
     "snazzy": "^4.0.0",
     "standard": "^7.1.2"


### PR DESCRIPTION
See #4

@rrdelaney would you want to enable Travis for this repository?  Just makes me feel safer when creating PRs :smile:  
[Here's](https://travis-ci.org/CodeLenny/ava-rethinkdb/builds/256686196) the Travis CI build output for one of these commits.

Changes:
- Updated AVA in `devDependencies`
- Added AVA to `peerDependencies` so users will be warned if they try to use versions of AVA with breaking changes beyond what we support
- Added `.travis.yml` for Travis CI testing, testing against Node.js v6 and v8, and against AVA v0.15.2 and v0.21.0