### PR TITLE
Fix 'cleanup()' removing all data directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "standard": "^7.1.2"
   },
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2"
   },
   "standard": {


### PR DESCRIPTION
See #4.

Tests are currently failing, as the `.travis.yml` file is in #5.

Changes:
- Added `mkdirp` as a dependency
- Switched database storage from `${process.cwd()/.db-test-${port}` to `${process.cwd()}/.db-test-${pid}/${port}` to reduce conflicts
- Added `getStorageDir()` helper
- Used `getStorageDir()` in `init()` and `cleanup()` to prevent `cleanup()` from removing data directories from other tests.