### PR TITLE
Test Multiple Instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "type": "git",
     "url": "https://github.com/rrdelaney/ava-rethinkdb"
   },
-  "keywords": [
-    "ava",
-    "rethinkdb"
-  ],
+  "keywords": ["ava", "rethinkdb"],
   "author": "Ryan Delaney <rrdelaney@outlook.com>",
   "license": "MIT",
   "bugs": {
@@ -22,6 +19,7 @@
   "homepage": "https://github.com/rrdelaney/ava-rethinkdb",
   "devDependencies": {
     "ava": "^0.15.2",
+    "babel-eslint": "^7.2.3",
     "rethinkdb": "^2.3.2",
     "snazzy": "^4.0.0",
     "standard": "^7.1.2"
@@ -30,8 +28,6 @@
     "rimraf": "^2.5.2"
   },
   "standard": {
-    "ignore": [
-      "test"
-    ]
+    "parser": "babel-eslint"
   }
 }

--- a/test/helpers/single-instance.js
+++ b/test/helpers/single-instance.js
@@ -1,0 +1,11 @@
+import test from "ava";
+import r from 'rethinkdb';
+import { init, cleanup } from '../../';
+
+test.before('Initialize DB', init());
+test.after.always('Teardown DB', cleanup);
+
+test("connects to database", async t => {
+  let connection = await r.connect({});
+  t.true(connection.open);
+});

--- a/test/helpers/single-instance.js
+++ b/test/helpers/single-instance.js
@@ -1,11 +1,11 @@
-import test from "ava";
-import r from 'rethinkdb';
-import { init, cleanup } from '../../';
+import test from 'ava'
+import r from 'rethinkdb'
+import { init, cleanup } from '../../'
 
-test.before('Initialize DB', init());
-test.after.always('Teardown DB', cleanup);
+test.before('Initialize DB', init())
+test.after.always('Teardown DB', cleanup)
 
-test("connects to database", async t => {
-  let connection = await r.connect({});
-  t.true(connection.open);
-});
+test('connects to database', async t => {
+  let connection = await r.connect({})
+  t.true(connection.open)
+})

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -16,9 +16,9 @@ const TEST_DATA = {
   },
   test: {
     data: [
-      { something: true },
-    ],
-  },
+      { something: true }
+    ]
+  }
 }
 
 test.before('Initialize DB', init(TEST_DATA))

--- a/test/multiple-instances/instance1.js
+++ b/test/multiple-instances/instance1.js
@@ -1,0 +1,11 @@
+import test from "ava";
+import r from 'rethinkdb';
+import { init, cleanup } from '../../';
+
+test.before('Initialize DB', init());
+test.after.always('Teardown DB', cleanup);
+
+test("connects to database", async t => {
+  let connection = await r.connect({});
+  t.true(connection.open);
+});

--- a/test/multiple-instances/instance1.js
+++ b/test/multiple-instances/instance1.js
@@ -1,11 +1,11 @@
-import test from "ava";
-import r from 'rethinkdb';
-import { init, cleanup } from '../../';
+import test from 'ava'
+import r from 'rethinkdb'
+import { init, cleanup } from '../../'
 
-test.before('Initialize DB', init());
-test.after.always('Teardown DB', cleanup);
+test.before('Initialize DB', init())
+test.after.always('Teardown DB', cleanup)
 
-test("connects to database", async t => {
-  let connection = await r.connect({});
-  t.true(connection.open);
-});
+test('connects to database', async t => {
+  let connection = await r.connect({})
+  t.true(connection.open)
+})

--- a/test/multiple-instances/instance2.js
+++ b/test/multiple-instances/instance2.js
@@ -1,0 +1,11 @@
+import test from "ava";
+import r from 'rethinkdb';
+import { init, cleanup } from '../../';
+
+test.before('Initialize DB', init());
+test.after.always('Teardown DB', cleanup);
+
+test("connects to database", async t => {
+  let connection = await r.connect({});
+  t.true(connection.open);
+});

--- a/test/multiple-instances/instance2.js
+++ b/test/multiple-instances/instance2.js
@@ -1,11 +1,11 @@
-import test from "ava";
-import r from 'rethinkdb';
-import { init, cleanup } from '../../';
+import test from 'ava'
+import r from 'rethinkdb'
+import { init, cleanup } from '../../'
 
-test.before('Initialize DB', init());
-test.after.always('Teardown DB', cleanup);
+test.before('Initialize DB', init())
+test.after.always('Teardown DB', cleanup)
 
-test("connects to database", async t => {
-  let connection = await r.connect({});
-  t.true(connection.open);
-});
+test('connects to database', async t => {
+  let connection = await r.connect({})
+  t.true(connection.open)
+})

--- a/test/port-offset.js
+++ b/test/port-offset.js
@@ -12,4 +12,4 @@ test('port offsets shouldn\'t exceed the maximum offset', async t => {
   t.true(getPortOffset(maxOffset) <= maxOffset)
   t.true(getPortOffset(maxOffset * 2) <= maxOffset)
   t.true(getPortOffset(maxOffset * 2.5) <= maxOffset)
-});
+})


### PR DESCRIPTION
See #4.  Unit tests to make sure that `rethinkdb` can be connected to from multiple instances without the internal data directories from `ava-rethinkdb` colliding.

Tests are currently failing, as they need the fix in #6.