### PR TITLE
Set 'node' Engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/rrdelaney/ava-rethinkdb/issues"
   },
   "homepage": "https://github.com/rrdelaney/ava-rethinkdb",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "peerDependencies": {
     "ava": "^0.21.0 || <= 0.21.0"
   },


### PR DESCRIPTION
`ava-rethinkdb` currently uses `const` and other ES6 features that aren't supported in Node versions prior to 6.0.0 ([source](http://node.green/)).

Setting the supported `node` versions in `package.json` will warn (and prevent) future users from trying to use `ava-rethinkdb` on unsupported platforms, and help developers know which ES6 features they can and can't use without breaking the package for users.