### PR TITLE
Fixed NPM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Testing utilities for RethinkDB and AVA
 
-[![ava-rethinkdb on NPM](https://img.shields.io/npm/v/npm.svg)](https://npm.im/ava-rethinkdb)
+[![ava-rethinkdb on NPM](https://img.shields.io/npm/v/ava-rethinkdb.svg)](https://npm.im/ava-rethinkdb)
 [![Build Status](https://travis-ci.org/rrdelaney/ava-rethinkdb.svg?branch=master)](https://travis-ci.org/rrdelaney/ava-rethinkdb)
 ![See package.json for Node.js Support](https://img.shields.io/node/v/ava-rethinkdb.svg?label=Runs%20on%20Node.js)
 


### PR DESCRIPTION
Oops, I forgot to replace part of the default NPM badge, so it's displaying the version of NPM, not of `ava-rethinkdb`.

Quick patch!